### PR TITLE
Remove deprecated 'document_relateditems' macro.

### DIFF
--- a/Products/CMFBibliographyAT/skins/bibliography/bibdocument_view.pt
+++ b/Products/CMFBibliographyAT/skins/bibliography/bibdocument_view.pt
@@ -37,10 +37,6 @@
             <div tal:replace="structure text" />
         </div>
 
-        <div metal:use-macro="here/document_relateditems/macros/relatedItems">
-            show related items if they exist
-        </div>
-
         <div metal:use-macro="here/document_actions/macros/document_actions">
             Document actions (print, sendto etc)
         </div>

--- a/Products/CMFBibliographyAT/skins/bibliography/bibliography_entry_view.pt
+++ b/Products/CMFBibliographyAT/skins/bibliography/bibliography_entry_view.pt
@@ -16,10 +16,6 @@
           Show where we came from
         </div>
 
-         <div metal:use-macro="here/document_relateditems/macros/relatedItems">
-            show related items if they exist
-        </div>
-    
         <div tal:replace="structure provider:plone.belowcontentbody" />
     </tal:main-macro>
 


### PR DESCRIPTION
The macro was converted to a viewlet in 4.0 and deprecated: https://dev.plone.org/ticket/9985

Opening a 'Bibliography Folder' throws `AttributeError: document_relateditems` in Plone 4.3.3.