### PR TITLE
Plone 4.x compability.

### DIFF
--- a/Products/CMFBibliographyAT/skins/bibliography/bibdocument_view.pt
+++ b/Products/CMFBibliographyAT/skins/bibliography/bibdocument_view.pt
@@ -37,10 +37,6 @@
             <div tal:replace="structure text" />
         </div>
 
-        <div metal:use-macro="here/document_relateditems/macros/relatedItems">
-            show related items if they exist
-        </div>
-
         <div metal:use-macro="here/document_actions/macros/document_actions">
             Document actions (print, sendto etc)
         </div>

--- a/Products/CMFBibliographyAT/skins/bibliography/bibliography_entry_view.pt
+++ b/Products/CMFBibliographyAT/skins/bibliography/bibliography_entry_view.pt
@@ -16,10 +16,6 @@
           Show where we came from
         </div>
 
-         <div metal:use-macro="here/document_relateditems/macros/relatedItems">
-            show related items if they exist
-        </div>
-    
         <div tal:replace="structure provider:plone.belowcontentbody" />
     </tal:main-macro>
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,11 @@ In addition the package adds a 'bibliography' action to the portal tabs and it
 provides a BibliographyTool called 'portal_bibliography' through which you can
 manage the renderers and parsers for the import/export functionality.
 
+Warning
+=======
+
+1.1.x is only to be used with Plone 3.x and 1.2.x is only to be used with Plone 4.x and up.
+
 
 Installation
 ============

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.2.0 (2015-12-14)
+------------------
+
+* Compability with Plone 4. Macro 'relatedItems' is deprecated https://dev.plone.org/ticket/9985
+
 1.1.5 (unreleased)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.1.5-unreleased'
+version = '1.2.0'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()


### PR DESCRIPTION
The macro was converted to a viewlet in 4.0 and deprecated: https://dev.plone.org/ticket/9985

Opening a 'Bibliography Folder' throws `AttributeError: document_relateditems` in Plone 4.3.3.